### PR TITLE
fix: jest config

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -5,7 +5,7 @@ module.exports = {
     verbose: true,
     testPathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/dist/'],
     collectCoverage: true,
-    collectCoverageFrom: ['src/**/*.ts'],
+    collectCoverageFrom: ['src/**/*.ts', '__data__/**/*.ts'],
     coverageReporters: ['text'],
     coverageThreshold: {
         global: {

--- a/jest.config.js
+++ b/jest.config.js
@@ -3,8 +3,9 @@ module.exports = {
     preset: 'ts-jest',
     testEnvironment: 'node',
     verbose: true,
+    testPathIgnorePatterns: ['<rootDir>/node_modules/', '<rootDir>/dist/'],
     collectCoverage: true,
-    collectCoverageFrom: ['src/**.ts'],
+    collectCoverageFrom: ['src/**/*.ts'],
     coverageReporters: ['text'],
     coverageThreshold: {
         global: {

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
         "fmt": "prettier --write --log-level warn .",
         "fmt:check": "prettier --check .",
         "lint": "eslint src/ __tests__/",
-        "test:unit": "jest --coverage __tests__/**.test.ts",
+        "test:unit": "jest --coverage",
         "test": "npm run test:unit",
         "prepare": "husky"
     },


### PR DESCRIPTION
This removes the need to explicitly have the path in the jest npm script; and fixes the config so that
1. the build artifacts are ignored, if present; and 
2. the coverage is collected for the source and data directories recursively, intead of just at the top level.