### PR TITLE
ci(dependabot): group updates & run daily

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,5 +9,10 @@ updates:
     directory: "/" # Location of package manifests
     schedule:
       interval: "weekly"
+      interval: "daily"
     commit-message:
       prefix: "chore(deps):"
+    groups:
+      version:
+        applies-to: version-updates
+        patterns: ['*']


### PR DESCRIPTION
Consolidate non-security version updates into one PR, and set it to run daily instead of weekly.